### PR TITLE
Removed `Droplet based protocols` option

### DIFF
--- a/docs/source/pipelines.rst
+++ b/docs/source/pipelines.rst
@@ -10,8 +10,7 @@ Here is the list of pipelines we develop:
 1. `RNA-seq <https://github.com/cellgeni/rnaseq-noqc>`_ (both bulk and Smartseq2)
 2. `ATAC-seq <https://github.com/cellgeni/atacseq>`_
 3. `TraCeR/BraCer <https://github.com/cellgeni/tracer>`_
-4. Droplet based protocols (inDrop, Seq-Well, Drop-seq)
-5. `10X cellranger <https://github.com/cellgeni/10xcellranger>`_
+4. `10X cellranger <https://github.com/cellgeni/10xcellranger>`_
 
 .. note:: If you would like to run ``cellranger`` by *10X* please put in a ticket for the NPG group by emailing to new-seq-pipe@sanger.ac.uk and specify which version of the cellranger and the genome you would like to use.
 


### PR DESCRIPTION
As we do not offer the `Droplet based protocols` option I have removed it from the options list.